### PR TITLE
Fixed etcd install failure on `make install`

### DIFF
--- a/addons/etcd-operator/Makefile
+++ b/addons/etcd-operator/Makefile
@@ -3,7 +3,9 @@ MAXTIMES = 3
 install:
 	helm upgrade --install etcd-operator stable/etcd-operator
 	for i in {1..$(MAXTIMES)}; \
-		do kubectl apply -f etcd-cluster.yaml; if [ $$? == '0' ]; then break; fi; sleep 5; \
+		do kubectl apply -f etcd-cluster.yaml; \
+		if [ $$? == '0' ]; then break; fi; \
+		sleep 5; \
 	done \
 
 uninstall:

--- a/addons/etcd-operator/Makefile
+++ b/addons/etcd-operator/Makefile
@@ -1,9 +1,13 @@
+MAXTIMES = 3
+
 install:
 	helm upgrade --install etcd-operator stable/etcd-operator
-	kubectl apply -f etcd-cluster.yaml
+	for i in {1..$(MAXTIMES)}; \
+		do kubectl apply -f etcd-cluster.yaml; if [ $$? == '0' ]; then break; fi; sleep 5; \
+	done \
 
 uninstall:
-	kubectl delete -f etcd-cluster.yaml
+	kubectl delete -f etcd-cluster.yaml --ignore-not-found
 	helm delete --purge etcd-operator
 
 .PHONY: install uninstall


### PR DESCRIPTION
## Fix for failed Etcd-operator

This adds a loop and wait to ensure that ETCD can be installed

closes #22 